### PR TITLE
dependabotの導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps(docker)"
+    open-pull-requests-limit: 5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy AS base
+FROM ubuntu@sha256:01a3ee0b5e413cefaaffc6abe68c9c37879ae3cced56a8e088b1649e5b269eee AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
- Dockerfileの監視
- イメージのタグをIDからSHA256ベースに変更して検出しやすくした