### PR TITLE
PRするべきリポジトリの追加

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,9 +11,9 @@ on:
   # 手動実行のためのトリガー
   workflow_dispatch:
 
-env:
-  # プルリクエストを送るべきリポジトリ名
-  REPO: densuke/2025-network-doc
+# env:
+#   # プルリクエストを送るべきリポジトリ名
+#   REPO: densuke/2025-network-doc
 
 # GHCRへプッシュできるよう権限を設定
 permissions:
@@ -159,11 +159,18 @@ jobs:
       - make_serial
       - test_act
     if: needs.check-act.outputs.IS_ACT != 'true'
+    strategy:
+      fail-fast: true
+      matrix:
+        # テンプレートリポジトリの更新は、amd64とarm64の両方で行う
+        - repo:
+          - densuke/2025-network-doc
+          - densuke/sphinx-doc-template
     steps:
       - name: リポジトリのクローン
         uses: actions/checkout@v4
         with:
-          repository: ${{ env.REPO }}
+          repository: ${{ matrix.repo }}
           token: ${{ secrets.TEMPLATE_TOKEN }}
           path: template-repo
 


### PR DESCRIPTION
このイメージを使っているイメージが複数になったので、とりあえずリポジトリをmatrixで追加する形にしました。

もしかすると、GitHub Actions Variablesで処理した方がワークフローファイルを書き換えずに済む分マシですか?
とりあえずまずは動くことが先。Variablesを使うかは今後の検討課題とします。