### PR TITLE
TeXLiveのインストール時にadjustboxパッケージを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ done
 hash -r
 tlmgr install wrapfig capt-of framed upquote needspace \
     tabulary varwidth titlesec latexmk cmap float wrapfig \
-    fancyvrb booktabs parskip 
+    fancyvrb booktabs parskip adjustbox
 # Clean up
 cd /tmp
 rm -rf /tmp/texlive


### PR DESCRIPTION
画像の割り付け位置の調整用にadjustboxが必要になったので、依存関係に追加しました。